### PR TITLE
Use new core MunkiOptionalReceiptEditor

### DIFF
--- a/CrowdStrike/CrowdStrikeFalcon.munki.recipe
+++ b/CrowdStrike/CrowdStrikeFalcon.munki.recipe
@@ -249,15 +249,15 @@ writelog "*****  Install CrowdStrike Process:  COMPLETE  *****"</string>
             <string>PathDeleter</string>
         </dict>
         <dict>
-          <key>Processor</key>
-    			<string>com.github.keeleysam.recipes.GoogleTalkPlugin/MunkiPkginfoReceiptsEditor</string>
-    			<key>Arguments</key>
-    			<dict>
-    				<key>pkg_ids_set_optional_true</key>
-    				<array>
-    					<string>com.crowdstrike.falcon.sensor.kext</string>
-    				</array>
-    			</dict>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_ids_set_optional_true</key>
+                <array>
+                    <string>com.crowdstrike.falcon.sensor.kext</string>
+                </array>
+            </dict>
+            <key>Processor</key>
+            <string>MunkiOptionalReceiptEditor</string>
         </dict>
       </array>
 </dict>

--- a/CrowdStrike/CrowdStrikeFalcon.munki.recipe
+++ b/CrowdStrike/CrowdStrikeFalcon.munki.recipe
@@ -251,6 +251,15 @@ writelog "*****  Install CrowdStrike Process:  COMPLETE  *****"</string>
         <dict>
             <key>Arguments</key>
             <dict>
+                <key>predicate</key>
+                <string>pkginfo_repo_path == ''</string>
+            </dict>
+            <key>Processor</key>
+            <string>StopProcessingIf</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
                 <key>pkg_ids_set_optional_true</key>
                 <array>
                     <string>com.crowdstrike.falcon.sensor.kext</string>


### PR DESCRIPTION
MunkiPkginfoReceiptsEditor is no longer maintained and has been replaced by [MunkiOptionalReceiptEditor](https://github.com/autopkg/autopkg/blob/master/Code/autopkglib/MunkiOptionalReceiptEditor.py) in autopkg core.