### PR TITLE
Adds fluent-bit recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
 
 This repo contains [AutoPkg](https://github.com/autopkg/autopkg) recipes used to package and deploy software. Unless otherwise noted, these recipes are available under the terms of the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-## Recipes
+## fluent-bit
 
-* Asix **.download** and **.munki** recipes grab the latest version of drivers for AX88179 ethernet adapters, such as StarTech USB31000S.
-* Gravitational Teleport **.download** and **.munki** recipes grab the latest version of [Teleport](https://gravitational.com/teleport/).
-* Krita **.download** and **.munki** recipes grab the latest version of [Krita](https://krita.org).
-* Nessus  **.download** and **.munki** recipes to grab the latest version of the macOS Tenable Nessus Agent.
-* SensibleSideButtons **.download** and **.munki** recipes to grab the latest version of SensibleSideButtons. Requires a Github API token stored at `~/.autopkg_gh_token`.
+Requires the `RELEASE_REPO` input variable.
+
+## DevSpace
+
+## CrowdStrike
+
+Deprecated fork of https://github.com/autopkg/MLBZ521-recipes/blob/master/CrowdStrike%20Falcon
+
+## AWSCLIv2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo contains [AutoPkg](https://github.com/autopkg/autopkg) recipes used to
 
 ## fluent-bit
 
-Requires the `RELEASE_REPO` input variable.
+Requires the `RELEASE_REPO` and `GITHUB_TOKEN` input variables.
 
 ## DevSpace
 

--- a/fluent-bit/config/fluent-bit-config.download.recipe
+++ b/fluent-bit/config/fluent-bit-config.download.recipe
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Fluent Bit is a super fast, lightweight, and highly scalable logging and metrics processor and forwarder.</string>
+	<key>Identifier</key>
+	<string>com.github.w0de.download.fluent-bit-config</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>fluent-bit-config</string>
+	</dict>
+	<key>MiniumumVersion</key>
+	<string>1.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+			<key>Arguments</key>
+			<dict>
+				<key>asset_regex</key>
+				<string>.*\.pkg</string>
+				<key>github_repo</key>
+				<string>faire/it-cpe-fluentbit</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%asset_url%</string>
+				<key>filename</key>
+				<string>it-cpe-fluent-bit-config-%version%.pkg</string>
+				<key>request_headers</key>
+				<dict>
+					<key>Authorization</key>
+					<string>token %GITHUB_TOKEN%</string>
+					<key>Accept</key>
+					<string>application/octet-stream</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/fluent-bit/config/fluent-bit-config.munki.recipe
+++ b/fluent-bit/config/fluent-bit-config.munki.recipe
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ParentRecipe</key>
+  <string>com.github.w0de.download.fluent-bit-config</string>
+	<key>Description</key>
+	<string>Fluent Bit is a super fast, lightweight, and highly scalable logging and metrics processor and forwarder.</string>
+	<key>Identifier</key>
+	<string>com.github.w0de.munki.fluent-bit-config</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>fluent-bit-config</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>unattended_install</key>
+			<true/>
+			<key>display_name</key>
+			<string>fluent-bit-config</string>
+			<key>developer</key>
+			<string>fluentbit.io</string>
+			<key>category</key>
+			<string>Utilities</string>
+			<key>catalogs</key>
+			<array>
+				<string>import</string>
+			</array>
+		</dict>
+	</dict>
+	<key>MiniumumVersion</key>
+	<string>1.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>description</key>
+					<string>%release_notes%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>repo_subdirectory</key>
+				<string>utilities</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
+				<key>pkg_path</key>
+        <string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/fluent-bit/fluent-bit.download.recipe
+++ b/fluent-bit/fluent-bit.download.recipe
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Fluent Bit is a super fast, lightweight, and highly scalable logging and metrics processor and forwarder.</string>
+	<key>Identifier</key>
+	<string>com.github.w0de.download.fluent-bit</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>fluent-bit</string>
+		<key>RELEASE_REPO</key>
+		<string>org/your-private-repo</string>
+	</dict>
+	<key>MiniumumVersion</key>
+	<string>1.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Processor</key>
+			<string>GitHubReleasesInfoProvider</string>
+			<key>Arguments</key>
+			<dict>
+				<key>asset_regex</key>
+				<string>.*\.pkg</string>
+				<key>github_repo</key>
+				<string>%RELEASE_REPO%</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>%asset_url%</string>
+				<key>filename</key>
+				<string>it-cpe-fluent-bit-logger-%version%.pkg</string>
+				<key>request_headers</key>
+				<dict>
+					<key>Authorization</key>
+					<string>token %GITHUB_TOKEN%</string>
+					<key>Accept</key>
+					<string>application/octet-stream</string>
+				</dict>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/fluent-bit/fluent-bit.munki.recipe
+++ b/fluent-bit/fluent-bit.munki.recipe
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>ParentRecipe</key>
+  <string>com.github.w0de.download.fluent-bit</string>
+	<key>Description</key>
+	<string>Fluent Bit is a super fast, lightweight, and highly scalable logging and metrics processor and forwarder.</string>
+	<key>Identifier</key>
+	<string>com.github.w0de.munki.fluent-bit</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>fluent-bit</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>unattended_install</key>
+			<true/>
+			<key>display_name</key>
+			<string>fluent-bit</string>
+			<key>developer</key>
+			<string>fluentbit.io</string>
+			<key>category</key>
+			<string>Utilities</string>
+			<key>catalogs</key>
+			<array>
+				<string>import</string>
+			</array>
+		</dict>
+	</dict>
+	<key>MiniumumVersion</key>
+	<string>1.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>additional_pkginfo</key>
+				<dict>
+					<key>description</key>
+					<string>%release_notes%</string>
+				</dict>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiPkginfoMerger</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>repo_subdirectory</key>
+				<string>utilities</string>
+				<key>version_comparison_key</key>
+				<string>CFBundleVersion</string>
+				<key>pkg_path</key>
+        <string>%pathname%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Recipe is intended to be used to retrieve released builds of fluent-bit from a third-party repo. Includes a recipe for standalone fluent-bit-config package. Updates README.